### PR TITLE
Add support for setting a Go version

### DIFF
--- a/cgo.go
+++ b/cgo.go
@@ -44,6 +44,21 @@ func close(filePath *C.char) {
 	removeArena(fp)
 }
 
+//export setGoVersion
+func setGoVersion(filePath *C.char, version *C.char) C.int {
+	fp := C.GoString(filePath)
+	f := getFile(fp)
+	if f == nil {
+		return 0
+	}
+	ver := C.GoString(version)
+	err := f.SetGoVersion(ver)
+	if err != nil {
+		return 0
+	}
+	return 1
+}
+
 //export getCompilerVersion
 func getCompilerVersion(filePath *C.char) *C.struct_compilerVersion {
 	fp := C.GoString(filePath)


### PR DESCRIPTION
This allows setting a Go version for the analysis. This can be used to assume a version when gore doesn't find the right version.