### PR TITLE
build fat-mach-o binary for pygore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,12 @@ WINDOWS_BUILD_FOLDER=build/windows
 TAR_ARGS=cfz
 RELEASE_FILES=LICENSE README.md
 
+ARCH=GOARCH=amd64
 CGO=CGO_ENABLED=1
 BUILD_OPTS=-ldflags="-s -w" -buildmode=c-shared
 WINDOWS_GO_ENV=GOOS=windows $(ARCH) $(CGO) CC=x86_64-w64-mingw32-gcc
 LINUX_GO_ENV=GOOS=linux $(ARCH) $(CGO)
-DARWIN_GO_ENV=GOOS=darwin $(ARCH) $(CGO)
+DARWIN_GO_ENV=GOOS=darwin $(CGO)
 
 .DEFAULT_GOAL := help
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ WINDOWS_BUILD_FOLDER=build/windows
 TAR_ARGS=cfz
 RELEASE_FILES=LICENSE README.md
 
-ARCH=GOARCH=amd64
 CGO=CGO_ENABLED=1
 BUILD_OPTS=-ldflags="-s -w" -buildmode=c-shared
 WINDOWS_GO_ENV=GOOS=windows $(ARCH) $(CGO) CC=x86_64-w64-mingw32-gcc
@@ -47,7 +46,10 @@ help:
 .PHONY: darwin
 darwin: ## Make binary for macOS
 	@echo -e "$(OK_COLOR)[$(APP)] Build for macOS$(NO_COLOR)"
-	@$(DARWIN_GO_ENV) $(GO) build -o $(APP).dylib $(BUILD_OPTS) .
+	@GOARCH=amd64 $(DARWIN_GO_ENV) $(GO) build -o $(APP).amd64.dylib $(BUILD_OPTS) .
+	@GOARCH=arm64 $(DARWIN_GO_ENV) $(GO) build -o $(APP).arm64.dylib $(BUILD_OPTS) .
+	@lipo -create -output $(APP).dylib $(APP).amd64.dylib $(APP).arm64.dylib
+	@rm $(APP).amd64.dylib $(APP).arm64.dylib
 
 .PHONY: windows
 windows: ## Make binary for Windows


### PR DESCRIPTION
Fixed an issue with [pygore](https://github.com/goretk/pygore) where the [pip pygore package](https://github.com/goretk/pygore/issues/20) comes with amd64 compiled `libgore.dylib` and lacks support for Applie Silicon arm64 architecture.

The Makefile was changed to compile both an amd64 and an arm64 version and create a fat-mach-o universal `libgore.dylib` binary.

Tested to work on my MBP M1 14"